### PR TITLE
fix condition in column_stats property

### DIFF
--- a/traceml/traceml/summary/df.py
+++ b/traceml/traceml/summary/df.py
@@ -77,7 +77,7 @@ class DataFrameSummary:
 
     @property
     def columns_stats(self):
-        if self._columns_stats:
+        if self._columns_stats is not None:
             return self._columns_stats
         self._columns_stats = df_processors.get_df_column_stats(self.df)
         return self._columns_stats


### PR DESCRIPTION
`if self._columns_stats` raises the following exception 

```
ValueError: The truth value of a DataFrame is ambiguous. Use a.empty, a.bool(), a.item(), a.any() or a.all().
```

when `self._columns_stats` is not `None`.  To fix this, it's enough to add `is None`. 